### PR TITLE
fix(spaces): Now there is a way to override the rule for gaps

### DIFF
--- a/scss/mixins/space.scss
+++ b/scss/mixins/space.scss
@@ -40,7 +40,7 @@
 @mixin sb-gaps-v($val, $prefix: '') {
   $size: sb-str-replace($val + '', '.', 'x');
 
-  .#{$prefix}gaps-v-#{$size} > :not(:last-child):not(:only-child) {
+  .#{$prefix}gaps-v-#{$size} > :not(:last-child):not(:only-child):not(.no-gaps-v) {
     margin-bottom: #{$val}rem;
   }
 }
@@ -48,7 +48,7 @@
 @mixin sb-gaps-h($val, $prefix: '') {
   $size: sb-str-replace($val + '', '.', 'x');
 
-  .#{$prefix}gaps-h-#{$size} > :not(:last-child):not(:only-child) {
+  .#{$prefix}gaps-h-#{$size} > :not(:last-child):not(:only-child):not(.no-gaps-h) {
     margin-right: #{$val}rem;
   }
 }


### PR DESCRIPTION
example (html):
```
.gaps-v-2
  .lalala
  .no-gaps-v
  .lololo
  .hohoho
```
the `.no-gaps-v` element will not have margins (gaps)
